### PR TITLE
🔀 Updated Export Messages feature: Changed image export header to "ChatGPT" and linked to repository

### DIFF
--- a/app/components/exporter.tsx
+++ b/app/components/exporter.tsx
@@ -470,9 +470,9 @@ export function ImagePreviewer(props: {
           </div>
 
           <div>
-            <div className={styles["main-title"]}>ChatGPT Next Web</div>
+            <div className={styles["main-title"]}>ChatGPT</div>
             <div className={styles["sub-title"]}>
-              github.com/Yidadaa/ChatGPT-Next-Web
+              github.com/yeenbean/ChatGPT-Next-Web
             </div>
             <div className={styles["icons"]}>
               <ExportAvatar avatar={config.avatar} />


### PR DESCRIPTION
Adjusted the Export Messages feature to display "ChatGPT" as the header instead of "ChatGPT-Next-Web". The exporter now directs users to this GitHub repository instead of the parent repository to avoid confusion.